### PR TITLE
Use take() to switch scene without clone

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -81,12 +81,11 @@ async fn main() {
             break;
         }
 
-        if let Some(escene) = ctx.switch_scene_to.clone() {
+        if let Some(escene) = ctx.switch_scene_to.take() {
             current_scene = match escene {
                 EScene::MainMenu => Box::new(MainMenu::new(&mut ctx).await),
                 EScene::Gameplay => Box::new(Gameplay::new(&mut ctx).await),
             };
-            ctx.switch_scene_to = None;
         }
 
         next_frame().await

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -1,6 +1,3 @@
-/// enum of various scenes that exist
-// not sure if there's a better way to do this...
-#[derive(Clone, Debug)]
 pub enum EScene {
     Gameplay,
     MainMenu,


### PR DESCRIPTION
Simple change to use take so we don't have to clone EScene. I have some more ideas for small improvements if you are interested.